### PR TITLE
move to a common provider for the server; add a test for the code comple...

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To run the server, run:
 
     dart bin/dartpad_server.dart --port 8082
 
-The server will run from port 8082 and export several JSON APIs, like `/api/compile`
-and `/api/analyze`.
+The server will run from port 8082 and export several JSON APIs, like
+`/api/compile` and `/api/analyze`.
 
 ## See also
 
@@ -33,5 +33,6 @@ Please file reports on the
 ## License and Contributing
 
 Contributions welcome! Please read this short
-[guide](https://github.com/dart-lang/dartpad_server/wiki/Contributing) first. You can view
-our license [here](https://github.com/dart-lang/dartpad_server/blob/master/LICENSE).
+[guide](https://github.com/dart-lang/dartpad_server/wiki/Contributing) first.
+You can view our license
+[here](https://github.com/dart-lang/dartpad_server/blob/master/LICENSE).

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad_server.common_server;
+
+import 'dart:async';
+import 'dart:convert' show JSON;
+import 'dart:io';
+
+import 'analyzer.dart';
+import 'compiler.dart';
+
+abstract class ServerLogger {
+  void info(String message);
+}
+
+abstract class ServerCache {
+  Future<String> get(String key);
+  Future set(String key, String value, {Duration expiration});
+  Future remove(String key);
+}
+
+class ServerResponse {
+  final int statusCode;
+  final String data;
+  final String mimeType;
+
+  ServerResponse(this.statusCode, this.data, [this.mimeType]);
+
+  ServerResponse.badRequest(this.data):
+    statusCode = HttpStatus.BAD_REQUEST, mimeType = null;
+
+  ServerResponse.notImplemented(this.data):
+    statusCode = HttpStatus.NOT_IMPLEMENTED, mimeType = null;
+
+  String toString() => '[response ${statusCode}]';
+}
+
+class CommonServer {
+  final ServerLogger logger;
+  final ServerCache cache;
+
+  Analyzer analyzer;
+  Compiler compiler;
+
+  CommonServer(String sdkPath, this.logger, this.cache) {
+    analyzer = new Analyzer(sdkPath);
+    compiler = new Compiler(sdkPath);
+  }
+
+  Future<ServerResponse> handleComplete(String data) {
+    if (data.isEmpty) {
+      return new Future.value(
+          new ServerResponse.badRequest("No JSON data received"));
+    }
+
+    Map m = JSON.decode(data);
+
+    String source = m['source'];
+    if (source == null) {
+      return new Future.value(
+          new ServerResponse.badRequest("'source' parameter missing"));
+    }
+
+    int offset = m['offset'];
+    if (offset == null) {
+      return new Future.value(
+          new ServerResponse.badRequest("'offset' parameter missing"));
+    }
+
+    return new Future.value(
+        new ServerResponse.notImplemented('Unimplemented: /api/complete'));
+  }
+}

--- a/test/all.dart
+++ b/test/all.dart
@@ -7,11 +7,13 @@ library dartpad_server.all_test;
 import 'src/analyzer_test.dart' as analyzer_test;
 import 'src/bench_test.dart' as bench_test;
 import 'src/common_test.dart' as common_test;
+import 'common_server_test.dart' as common_server_test;
 import 'src/compiler_test.dart' as compiler_test;
 
 void main() {
   analyzer_test.defineTests();
   bench_test.defineTests();
   common_test.defineTests();
+  common_server_test.defineTests();
   compiler_test.defineTests();
 }

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad_server.common_server_test;
+
+import 'dart:async';
+import 'dart:convert' show JSON;
+
+import 'package:dartpad_server/src/common_server.dart';
+import 'package:grinder/grinder.dart' as grinder;
+import 'package:unittest/unittest.dart';
+
+void defineTests() {
+  CommonServer server;
+  MockLogger logger = new MockLogger();
+  MockCache cache = new MockCache();
+
+  group('CommonServer', () {
+    setUp(() {
+      if (server == null) {
+        String sdkPath = grinder.getSdkDir().path;
+        server = new CommonServer(sdkPath, logger, cache);
+      }
+    });
+
+    test('handleComplete', () {
+      String json = JSON.encode({'source': 'void main() {print("foo");}', 'offset': 1});
+      return server.handleComplete(json).then((ServerResponse response) {
+        expect(response.statusCode, 501);
+      });
+    });
+
+    test('handleComplete no data', () {
+      return server.handleComplete('').then((ServerResponse response) {
+        expect(response.statusCode, 400);
+      });
+    });
+
+    test('handleComplete param missing', () {
+      String json = JSON.encode({'offset': 1});
+      return server.handleComplete(json).then((ServerResponse response) {
+        expect(response.statusCode, 400);
+      });
+    });
+  });
+}
+
+class MockLogger implements ServerLogger {
+  StringBuffer builder = new StringBuffer();
+
+  void info(String message) => builder.write('${message}\n');
+  void clear() => builder.clear();
+  String getLog() => builder.toString();
+}
+
+class MockCache implements ServerCache {
+  Future<String> get(String key) => new Future.value(null);
+  Future set(String key, String value, {Duration expiration}) =>
+      new Future.value();
+  Future remove(String key) => new Future.value();
+}


### PR DESCRIPTION
Move to share code between the non-ae server and the ae server. Abstract out the various dependencies. This has the nice side benefit of making the server implementations easily testable.

@lukechurch 

Only the code complete service is moved over. The other 3 will need to be as well. This should result in a lot less (duplicated) code.