### PR TITLE
add more error logging

### DIFF
--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -95,14 +95,13 @@ void invoke(String api, String source, Element output, {int offset}) {
   String url = '${_uriBase}${api}';
   output.text = '';
 
-  Map headers = {'Content-Type': 'application/json; charset=UTF-8'};
+  //Map headers = {'Content-Type': 'application/json; charset=UTF-8'};
 
   Map m = {'source': source};
   if (offset != null) m['offset'] = offset;
   String data = JSON.encode(m); //new Uri(queryParameters: m).query;
 
-  HttpRequest.request(url, requestHeaders: headers,
-      method: 'POST', sendData: data).then((HttpRequest r) {
+  HttpRequest.request(url, method: 'POST', sendData: data).then((HttpRequest r) {
     String response =
         '${r.status} ${r.statusText} - ${timer.elapsedMilliseconds}ms\n'
         '${r.responseHeaders}\n\n'

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -95,11 +95,14 @@ void invoke(String api, String source, Element output, {int offset}) {
   String url = '${_uriBase}${api}';
   output.text = '';
 
+  Map headers = {'Content-Type': 'application/json; charset=UTF-8'};
+
   Map m = {'source': source};
   if (offset != null) m['offset'] = offset;
   String data = JSON.encode(m); //new Uri(queryParameters: m).query;
 
-  HttpRequest.request(url, method: 'POST', sendData: data).then((HttpRequest r) {
+  HttpRequest.request(url, requestHeaders: headers,
+      method: 'POST', sendData: data).then((HttpRequest r) {
     String response =
         '${r.status} ${r.statusText} - ${timer.elapsedMilliseconds}ms\n'
         '${r.responseHeaders}\n\n'


### PR DESCRIPTION
@lukechurch, I'm seeing errors come back from the `document/` service when run on appegine. I don't see them locally. To repro, start the example/apitest.html application and use that last box (the document/ one). If your cursor is on `void`, you get results back. If it's on anything non-trivial, like `print`, you get a 500 error back. I'm assuming the server is throwing an exception, but am not sure.