### PR TITLE
whitelist OPTIONS requests

### DIFF
--- a/lib/dartpad_gae.dart
+++ b/lib/dartpad_gae.dart
@@ -35,7 +35,8 @@ class GaeServer {
   void requestHandler(io.HttpRequest request) {
     request.response.headers.add('Access-Control-Allow-Origin', '*');
     request.response.headers.add('Access-Control-Allow-Credentials', 'true');
-    request.response.headers.add('Access-Control-Allow-Methods', 'POST');
+    request.response.headers.add('Access-Control-Allow-Methods',
+        'POST, OPTIONS');
     request.response.headers.add('Access-Control-Allow-Headers',
         'Origin, X-Requested-With, Content-Type, Accept');
 

--- a/lib/dartpad_server.dart
+++ b/lib/dartpad_server.dart
@@ -140,7 +140,7 @@ Dartpad server.
   Middleware _createCorsMiddleware() {
     Map _corsHeader = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
     };
 


### PR DESCRIPTION
Fix https://github.com/dart-lang/dartpad_ui/issues/76.

@lukechurch, can you push a new version of the server? I think this PR will let Safari talk to the backend again.